### PR TITLE
Fix to support directories with spaces in them.

### DIFF
--- a/bin/generate_cert.sh
+++ b/bin/generate_cert.sh
@@ -24,7 +24,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
   echo "* Please install and trust cert at conf/$NAME.crt"
 fi
-cd $DIR 
+cd "$DIR" 
 if [[ ! -d "${DIR}/../conf/" ]]; then
   mkdir "${DIR}/../conf/"
 fi


### PR DESCRIPTION
Certs would still generate no problem, but moving them to /conf/ when under a sub-directory with spaces in it would cause a hiccup. Quick solution for it. :)