### PR TITLE
Add Support for Twitch usernames when starting the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,13 @@ The recommended path to using this sample is with the [Developer Rig](https://gi
 The Developer Rig is able to host the frontend Hello World files, but the EBS must be run separately. If you want to host your frontend files other than with the Developer Rig, run `node services/frontend` at the root of your project.
 
 ### Configuring and Running the Extension Backend Service
-To run the EBS, run `node services/backend`, with the following command line arguments: `-c <client id>`, `-s <secret>`, `-o <owner id>`
+Before you can run the EBS, you must first generate SSL certificates (see below). Once those are in place, you can start the EBS with `node services/backend`, with the following command line arguments: `-c <client id>`, `-s <secret>`, `-n <owner name>` 
 
-This provides the EBS with your Extension client ID, Extension secret and the user ID of the Extension owner (likely you). These are necessary to validate calls to your EBS and make calls to Twitch services such as PubSub.
+This provides the EBS with your Extension client ID, Extension secret and the user name of the Extension owner (likely you). These are necessary to validate calls to your EBS and make calls to Twitch services such as PubSub.
 
-If you do not want to pass in command line arguments, you can also directly set the following environment variables: `EXT_SECRET`, `EXT_CLIENT_ID`, `EXT_OWNER_ID` in your code.
+If you do not want to pass in command line arguments, you can also directly set the following environment variables: `EXT_SECRET`, `EXT_CLIENT_ID`, `EXT_OWNER_NAME` in your code.
 
 You can get your client ID and secret from your [Extension Dashboard](https://dev.twitch.tv/dashboard/extensions). See the documentation for the [Developer Rig](https://github.com/twitchdev/developer-rig#configuring-the-developer-rig) for more details.
-
-To get the owner ID, you will need to execute a simple CURL command against the Twitch /users endpoint. You'll need your extension client ID as part of the query (this will be made consistent with the Developer Rig shortly, by using _owner name_).
-
-```bash
-curl -H 'Client-ID: <client id>' -X GET 'https://api.twitch.tv/helix/users?login=<owner name>'
-```
-
-You will also need to generate a cert to run your EBS. See below for the steps to accomplish this.
 
 ### SSL Certificates
 Twitch Extensions require SSL (TLS).

--- a/services/backend.js
+++ b/services/backend.js
@@ -47,8 +47,8 @@ const STRINGS = {
     missing_secret: "Extension secret required.\nUse argument '-s <secret>' or env var 'EXT_SECRET'",
     missing_clientId: "Extension client ID required.\nUse argument '-c <client ID>' or env var 'EXT_CLIENT_ID'",
     missing_ownerId: "Extension owner ID required.\nUse argument '-o <owner ID>' or env var 'EXT_OWNER_ID'",
-    ownerId_retreival_error: "Failed to find a Twitch profile for the ownerName %s",
-    ownerId_retreival_success: "Matched Twitch owner ID %s with given username %s",
+    ownerId_retrieval_error: "Failed to find a Twitch profile for the ownerName %s",
+    ownerId_retrieval_success: "Matched Twitch owner ID %s with given username %s",
     message_send_error: "Error sending message to channel %s",
     pubsub_response: "Message to c:%s returned %s",
     cycling_color: "Cycling color for c:%s on behalf of u:%s",
@@ -96,10 +96,10 @@ if(!ext.ownerId) {
     if (ext.ownerName) {
         // Try to get the owner's ID from the name before exiting
         getOwnerIdFromName(ext.ownerName, (ownerId) => {
-            verboseLog(STRINGS.ownerId_retreival_success, ownerId, ext.ownerName);
+            verboseLog(STRINGS.ownerId_retrieval_success, ownerId, ext.ownerName);
             ext.ownerId = ownerId;
         }, (err) => {
-            console.log(STRINGS.ownerId_retreival_error, ext.ownerName);
+            console.log(STRINGS.ownerId_retrieval_error, ext.ownerName);
             process.exit(1);
         });
     }


### PR DESCRIPTION
## Purpose
Ideally, the 'Hello World' example for Twitch Extensions would match the patterns established in the Development Rig. This brings the initial startup in line with starting the Dev Rig by allowing users to specify their twitch username instead of having to grab the related ID's manually.

## What Does This Do?
* Adds a function that takes a given username and attempts to find the matching `owner_Id`
* Adds usage of the function, still exiting if an `owner_Id` cannot be found
* Maintains backwards compatibility for users still specifying `owner_Id` in env vars or on the command line. 
* Updates the README, removing copy about needing to manually lookup `owner_Id`. 
* Moves the line about needing an SSL cert to the top, so the user knows earlier to generate those (this temporarily tripped me up).

## Future Work
I would like to write tests for my additions, but it looks like there aren't any setup just yet and I assume the main maintainer would like to establish that pattern. 