### PR TITLE
Change process.platform check to work with Linux

### DIFF
--- a/bin/generate_cert.js
+++ b/bin/generate_cert.js
@@ -6,7 +6,7 @@ if(process.argv.length < 3) {
 
 // Spawn the process for the platform.
 const { spawn } = require('child_process');
-const cmd = process.platform === 'darwin' ?
+const cmd = process.platform !== 'win32' ?
   spawn('bin/generate_cert.sh', [process.argv[2]]) :
   spawn('cmd.exe', ['/c', 'bin\\generate_cert.cmd', process.argv[2]]);
 let output = '';


### PR DESCRIPTION
Making Windows the exceptional case likely makes this work fine on other *nix platforms as well.