### PR TITLE
Scheduling backend color broadcast with correct timeout

### DIFF
--- a/services/backend.js
+++ b/services/backend.js
@@ -201,7 +201,7 @@ function attemptColorBroadcast(channelId) {
     channelCooldowns[channelId] = { time: now + channelCooldownMs };
   } else if (!cooldown.trigger) {
     // It isn't; schedule a delayed broadcast if we haven't already done so.
-    cooldown.trigger = setTimeout(sendColorBroadcast, now - cooldown.time, channelId);
+    cooldown.trigger = setTimeout(sendColorBroadcast, cooldown.time - now, channelId);
   }
 }
 


### PR DESCRIPTION
Since there obviously is a cooldown set when we get to this condition, we need to subtract `cooldown.time` from `now` instead of subtracting `now` from `cooldown.time`, since `cooldown.time` is always greater than the current timestamp.

This currently results in negative timeout delays and fires the task immediately.