### PR TITLE
Adding Base64 decoding of the secret

### DIFF
--- a/services/backend.js
+++ b/services/backend.js
@@ -250,7 +250,7 @@ function makeServerToken(channelId) {
       send: ['*'],
     },
   };
-  return jsonwebtoken.sign(payload, secret, { algorithm: 'HS256' });
+  return jsonwebtoken.sign(payload, Buffer.from(secret, "base64"), { algorithm: 'HS256' });
 }
 
 function userIsInCooldown(opaqueUserId) {


### PR DESCRIPTION
The example does not work if the user does not first decode the secret token with Base64 (wich is not specified if i'm not mistaken)